### PR TITLE
Fix: Opens all tabs as non-previews - makes this extension usable again

### DIFF
--- a/src/Controller/Session/SessionController.ts
+++ b/src/Controller/Session/SessionController.ts
@@ -35,9 +35,9 @@ export default class SessionController {
         }
         try {
             await this.restore(nameOfSession);
-            await this.windowDelegate.showMessage(`You have switched to session "${nameOfSession}".`);
+            this.windowDelegate.showMessage(`You have switched to session "${nameOfSession}".`);
         } catch (exception) {
-            await this.windowDelegate.showMessage(`Session "${nameOfSession}" is not yet saved.`);
+            this.windowDelegate.showMessage(`Session "${nameOfSession}" is not yet saved.`);
         }
     }
 

--- a/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
+++ b/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
@@ -124,7 +124,7 @@ export default class VscodeSessionManagerDelegate implements SessionManagerDeleg
         for (const editor of session.editors) {
             const document = await vscode.workspace.openTextDocument(editor.uri);
             const viewColumn = editor.column >= 0 ? editor.column : undefined;
-            await vscode.window.showTextDocument(document, viewColumn);
+            await vscode.window.showTextDocument(document, {viewColumn: viewColumn, preview: false});
         };
     }
 }

--- a/src/Provider/Config/VscodeConfigProvider.ts
+++ b/src/Provider/Config/VscodeConfigProvider.ts
@@ -17,7 +17,7 @@ export default class VscodeConfigProvider implements ConfigProvider {
     }
 
     provide(): Config {
-        const shouldAutoRestoreOnBranchSwitches = this.config.get<boolean>('git-branch-wise-session.shouldAutoRestoreOnBranchSwitches', false);
+        const shouldAutoRestoreOnBranchSwitches = this.config.get<boolean>('shouldAutoRestoreOnBranchSwitches', false);
 
         return {
             shouldAutoRestoreOnBranchSwitches,


### PR DESCRIPTION
This PR fixes the issue wherein all tabs open as previews and replace one another on restore. 

@mangano-ito could you review it and release this extension. It would help a ton of people!