### PR TITLE
Auto Save

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Restore sessions automatically on Git branch switches."
+                },
+                "git-branch-wise-session.autoSaveBranchOnSwitch": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Automatically save the current session when swapping branches."
                 }
             }
         }

--- a/src/Controller/Session/SessionController.ts
+++ b/src/Controller/Session/SessionController.ts
@@ -20,16 +20,19 @@ export default class SessionController {
         configProvider.setOnConfigDirtyListener((config: Config) => { this.config = config; });
         sessionManagerDelegate.setOnSessionSaveRequestedListener((session) => this.onSessionUpdated(session));
         sessionManagerDelegate.setOnSessionRestoreRequestedListener((nameOfSession) => this.onSessionRestoreRequested(nameOfSession));
-        sessionManagerDelegate.setOnSessionSwitchedListener((nameOfSession: string) => this.onSessionSwitched(nameOfSession));
+        sessionManagerDelegate.setOnSessionSwitchedListener((nameOfSession: string, lastSession: Session | undefined) => this.onSessionSwitched(nameOfSession, lastSession));
         sessionManagerDelegate.setOnSessionAllClearRequestedListener(() => this.onSessionAllClearRequested());
     }
 
     async onSessionUpdated(session: Session) {
         this.repo.set(session);
-        await this.windowDelegate.showMessage(`Session "${session.name}" has been saved.`);
+        this.windowDelegate.showMessage(`Session "${session.name}" has been saved.`);
     }
 
-    async onSessionSwitched(nameOfSession: string) {
+    async onSessionSwitched(nameOfSession: string, lastSession: Session | undefined) {
+        if (this.config.autoSaveBranchOnSwitch && lastSession) {
+            await this.onSessionUpdated(lastSession);
+        }
         if (!this.config.shouldAutoRestoreOnBranchSwitches) {
             return;
         }

--- a/src/Delegate/Git/DefaultGitDelegate.ts
+++ b/src/Delegate/Git/DefaultGitDelegate.ts
@@ -23,7 +23,6 @@ export default class DefaultGitDelegate implements GitDelegate {
         }
         this.git = git;
 
-        // FIXME
         this.lastCurrentBranchName = this.currentBranchName;
 
         const initializer = this.git.onDidChangeState((e) => {

--- a/src/Delegate/Git/DefaultGitDelegate.ts
+++ b/src/Delegate/Git/DefaultGitDelegate.ts
@@ -25,14 +25,20 @@ export default class DefaultGitDelegate implements GitDelegate {
 
         // FIXME
         this.lastCurrentBranchName = this.currentBranchName;
-        // FIXME: what if a repository is newly set up after this initialization?
-        this.currentRepository?.state?.onDidChange(() => {
-            // emit only when current branch is switched
-            if (this.lastCurrentBranchName !== this.currentBranchName) {
-                this.lastCurrentBranchName = this.currentBranchName;
-                this.onBranchSwitchedListener(this.currentBranchName);
+
+        const initializer = this.git.onDidChangeState((e) => {
+            if (e === "initialized") {
+                this.currentRepository?.state?.onDidChange(async () => {
+                    // emit only when current branch is switched
+                    if (this.lastCurrentBranchName !== this.currentBranchName) {
+                        const tempLastBranchName = this.lastCurrentBranchName;
+                        this.lastCurrentBranchName = this.currentBranchName;
+                        this.onBranchSwitchedListener(this.currentBranchName, tempLastBranchName);
+                    }
+                });
+                initializer.dispose();
             }
-        });
+        }, this);
     }
 
     /** @inheritdoc */

--- a/src/Delegate/Git/GitDelegate.ts
+++ b/src/Delegate/Git/GitDelegate.ts
@@ -1,5 +1,5 @@
 /** listener called when branch is switched */
-export type OnBranchSwitchedListener = (nameOfBranch: string | undefined) => any;
+export type OnBranchSwitchedListener = (nameOfBranch: string | undefined, lastBranchName: string | undefined) => any;
 
 /**
  * Git-based Controller Delegate

--- a/src/Delegate/SessionManager/SessionManagerDelegate.ts
+++ b/src/Delegate/SessionManager/SessionManagerDelegate.ts
@@ -7,7 +7,7 @@ export type OnSessionSaveRequestedListener = (session: Session) => any;
 /** listener called when session restore is requested */
 export type OnSessionRestoreRequestedListener = (nameOfSession: string) => any;
 /** listener called on session switches */
-export type OnSessionSwitchedListener = (nameOfSession: string) => any;
+export type OnSessionSwitchedListener = (nameOfSession: string, lastSession: Session | undefined) => any;
 /** listener called when forget current session is requested */
 export type OnSessionClearRequestedListener = (nameOfSession: string) => any;
 /** listener called when forget all sessions is requested */

--- a/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
+++ b/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
@@ -45,8 +45,14 @@ export default class VscodeSessionManagerDelegate implements SessionManagerDeleg
                 this.onSessionUpdatedListener(this.intoSession(editors));
             }),
         );
-        this.gitDelegate.setOnBranchSwitchedListener(() => {
-            this.onSessionSwitchedListener(this.nameOfSession);
+        this.gitDelegate.setOnBranchSwitchedListener(async (_, lastBranchName) => {
+            this.onSessionSwitchedListener(
+                this.nameOfSession,
+                lastBranchName ? {
+                    ...(await this.getCurrentSession()),
+                    name: lastBranchName
+                } : undefined,
+            );
         });
     }
 

--- a/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
+++ b/src/Delegate/SessionManager/VscodeSessionManagerDelegate.ts
@@ -10,6 +10,8 @@ import SessionManagerDelegate, {
     OnSessionClearRequestedListener,
     OnSessionAllClearRequestedListener,
 } from './SessionManagerDelegate';
+import ConfigProvider from '#/Provider/Config/ConfigProvider';
+import Config from '#/Model/Config';
 
 const DEFAULT_SESSION_NAME = 'untitled session';
 
@@ -23,11 +25,14 @@ export default class VscodeSessionManagerDelegate implements SessionManagerDeleg
     private onSessionAllClearRequestedListener: OnSessionAllClearRequestedListener = () => {};
     private onSessionUpdatedListener: OnSessionUpdatedListener = () => {};
     private onSessionSwitchedListener: OnSessionSwitchedListener = () => {};
+    private config: Config;
 
     constructor(
         context: vscode.ExtensionContext,
         private gitDelegate: GitDelegate,
+        configProvider: ConfigProvider,
     ) {
+        this.config = configProvider.provide();
         context.subscriptions.push(
             vscode.commands.registerCommand('git-branch-wise-session.saveSession', async () => {
                 this.onSessionSaveRequestedListener(await this.getCurrentSession());
@@ -48,7 +53,7 @@ export default class VscodeSessionManagerDelegate implements SessionManagerDeleg
         this.gitDelegate.setOnBranchSwitchedListener(async (_, lastBranchName) => {
             this.onSessionSwitchedListener(
                 this.nameOfSession,
-                lastBranchName ? {
+                lastBranchName && this.config.autoSaveBranchOnSwitch ? {
                     ...(await this.getCurrentSession()),
                     name: lastBranchName
                 } : undefined,

--- a/src/Model/Config.ts
+++ b/src/Model/Config.ts
@@ -4,4 +4,6 @@
 export default interface Config {
     /** On branch switches, whether the extension should also switch sessions automatically. */
     shouldAutoRestoreOnBranchSwitches: boolean;
+    /** Whether the current session should be saved upon branches switching. */
+    autoSaveBranchOnSwitch: boolean;
 }

--- a/src/Provider/Config/VscodeConfigProvider.ts
+++ b/src/Provider/Config/VscodeConfigProvider.ts
@@ -19,9 +19,11 @@ export default class VscodeConfigProvider implements ConfigProvider {
     provide(): Config {
         this.config = vscode.workspace.getConfiguration('git-branch-wise-session');
         const shouldAutoRestoreOnBranchSwitches = this.config.get<boolean>('shouldAutoRestoreOnBranchSwitches', false);
+        const autoSaveBranchOnSwitch = this.config.get<boolean>('autoSaveBranchOnSwitch', false);
 
         return {
             shouldAutoRestoreOnBranchSwitches,
+            autoSaveBranchOnSwitch,
         };
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import VscodeConfigProvider from './Provider/Config/VscodeConfigProvider';
 export async function activate(context: vscode.ExtensionContext) {
 	const configProvider = new VscodeConfigProvider(context);
     const windowDelegate = new VscodeMainWindowDelegate();
-    const sessionManagerDelegate = new VscodeSessionManagerDelegate(context, new DefaultGitDelegate());
+    const sessionManagerDelegate = new VscodeSessionManagerDelegate(context, new DefaultGitDelegate(), configProvider);
     const repo = new StorageBackedSessionRepository(new WorkspaceStorage(context));
 
 	new SessionController(repo, sessionManagerDelegate, windowDelegate, configProvider);


### PR DESCRIPTION
# Description

Adds a new setting that auto-saves the current session upon the branch being switched when enabled. This feature was requested in https://github.com/mangano-ito/git-branch-wise-session/issues/16.

Also fixes a bug where the repository state change listener was not getting set up as it wasn't initialized on extension load.