### PR TITLE
Mention vscode-native support for tab - git branch sync in the README, maybe deprecate this project ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An Extension to keep Tabs for each Git branch.
 
-**NB : With the resolution of https://github.com/microsoft/vscode/issues/35307 and the [Vscode 1.89 release](https://code.visualstudio.com/updates/v1_89#_saverestore-open-editors-when-switching-branches), vscode now has native support for keeping open editors synced with the current git branch**
+**NB : With the resolution of https://github.com/microsoft/vscode/issues/35307 and the [Vscode 1.89 release](https://code.visualstudio.com/updates/v1_89#_saverestore-open-editors-when-switching-branches), vscode now has native support for keeping open editors synced with the current git branch, with the `scm.workingSets.enabled` (and optionally `scm.workingSets.default`) settings.**
 
 ## See It in Action
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An Extension to keep Tabs for each Git branch.
 
+**NB : With the resolution of https://github.com/microsoft/vscode/issues/35307 and the [Vscode 1.89 release](https://code.visualstudio.com/updates/v1_89#_saverestore-open-editors-when-switching-branches), vscode now has native support for keeping open editors synced with the current git branch**
+
 ## See It in Action
 
 ### Save and Restore Tabs on Git Branch Basis


### PR DESCRIPTION
Hi folks,

Thanks for this extension, I have extensively used over the last few months, and have found it really useful.

vscode has since added support for keeping open editor windows synced with the git branch, with the `scm.workingSets.enabled` and `scm.workingSets.default` (cf https://github.com/microsoft/vscode/issues/35307 and [release notes](https://code.visualstudio.com/updates/v1_89#_saverestore-open-editors-when-switching-branches)).

I have switched to it, and so far it seems to work perfectly, better even than this extension (tabs get replaced instantly, instead of openend and closed one by one ; which I'm assuming was due to limitations in the API offered by vscode to extensions).

I'm not sure whether this extension offers features that are not present in the upstream implementation, but even if that is the case, I believe it would make sense to let potential new users know that there is first-party support before using an extension for that, hence that PR.

Please feel free to change the wording proposed here if it's not deemed satisfying.

It may even make sense to officially consider this project as deprecated from now on ? I'll leave that choice up to you.


Thanks again for this project, it was a great workaround in the meantime.